### PR TITLE
Fix the pulid examples generate command

### DIFF
--- a/entgql/internal/todopulid/server/server.go
+++ b/entgql/internal/todopulid/server/server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/facebookincubator/ent-contrib/entgql"
 	todopulid "github.com/facebookincubator/ent-contrib/entgql/internal/todopulid"
 	"github.com/facebookincubator/ent-contrib/entgql/internal/todopulid/ent"
+	"github.com/facebookincubator/ent-contrib/entgql/internal/todopulid/ent/migrate"
 	"github.com/facebookincubator/ent-contrib/entgql/internal/todopulid/ent/todo"
 	"go.uber.org/zap"
 
@@ -50,7 +51,7 @@ func main() {
 	ctx := context.Background()
 	if err := client.Schema.Create(
 		ctx,
-		// migrate.WithGlobalUniqueID(true),
+		migrate.WithGlobalUniqueID(true),
 	); err != nil {
 		log.Fatal("running schema migration", zap.Error(err))
 	}


### PR DESCRIPTION
Pulling down the repo and running generate was throwing errors

```
❯ go generate ./...
validation failed: packages.Load: <project>todo.resolvers.go:20:23: cannot use todo.Parent (variable of type *pulid.ID) as *int value in argument to client.Todo.Create().SetStatus(todo.Status).SetNillablePriority(todo.Priority).SetText(todo.Text).SetNillableParentID
<project>todo.resolvers.go:32:29: cannot use id (variable of type pulid.ID) as int value in argument to r.client.Noder
<project>todo.resolvers.go:32:50: cannot use ent.IDToType (value of type func(ctx context.Context, id pulid.ID) (string, error)) as func(context.Context, int) (string, error) value in argument to ent.WithNodeType
<project>todo.resolvers.go:36:30: cannot use ids (variable of type []pulid.ID) as []int value in argument to r.client.Noders
<project>todo.resolvers.go:36:52: cannot use ent.IDToType (value of type func(ctx context.Context, id pulid.ID) (string, error)) as func(context.Context, int) (string, error) value in argument to ent.WithNodeType
exit status 1
gen.go:17: running "go": exit status 1
```

Seems like the code was run with the uncommented code before commit. 